### PR TITLE
Make the enabled checks configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ inputs:
     description: "allow submit approve review"
     required: true
     default: true
+  enable_checks:
+    description: "checks to enable"
+    required: true
+    default: "all"
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "allow submit approve review"
     required: true
     default: true
+  enable_checks:
+    description: "checks to enable"
+    required: true
+    default: "all"
 
 runs:
   using: "composite"
@@ -30,7 +34,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get install -y -q cppcheck
-        cppcheck --enable=all --output-file=report.xml --xml .
+        cppcheck --enable=${{ inputs.enable_checks }} --output-file=report.xml --xml .
     - name: install action bin
       shell: bash
       run: |


### PR DESCRIPTION
The checks to perform can be configured from the action as an input. The
default is "all", but it can be set to other options.

I did a test run with sssd that can be reviewed in [link](https://github.com/ikerexxe/sssd/runs/5553197395?check_suite_focus=true).