### PR TITLE
Update to latest setup-go with Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
         cppcheck --enable=${{ inputs.enable_checks }} --suppress='*:*3rdparty*' --output-file=report.xml --xml .
 
     - name: install golang
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ^1.17.1
     - name: install action-cppcheck


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-go@v2